### PR TITLE
Fix code scanning alert no. 26: Server-side request forgery

### DIFF
--- a/src/fetchers/wakatime-fetcher.js
+++ b/src/fetchers/wakatime-fetcher.js
@@ -12,11 +12,17 @@ const fetchWakatimeStats = async ({ username, api_domain }) => {
     throw new MissingParamError(["username"]);
   }
 
+  const allowedDomains = ["wakatime.com", "another-allowed-domain.com"];
+  const sanitizedUsername = encodeURIComponent(username);
+  const domain = api_domain ? api_domain.replace(/\/$/gi, "") : "wakatime.com";
+  
+  if (!allowedDomains.includes(domain)) {
+    throw new CustomError(`Invalid API domain: ${domain}`, "INVALID_API_DOMAIN");
+  }
+  
   try {
     const { data } = await axios.get(
-      `https://${
-        api_domain ? api_domain.replace(/\/$/gi, "") : "wakatime.com"
-      }/api/v1/users/${username}/stats?is_including_today=true`,
+      `https://${domain}/api/v1/users/${sanitizedUsername}/stats?is_including_today=true`,
     );
 
     return data.data;


### PR DESCRIPTION
Fixes [https://github.com/Necas209/github-readme-stats/security/code-scanning/26](https://github.com/Necas209/github-readme-stats/security/code-scanning/26)

To fix the SSRF vulnerability, we need to ensure that the `api_domain` is restricted to a set of known, safe domains. This can be achieved by using an allow-list of acceptable domains and selecting the domain based on user input. Additionally, we should validate the `username` parameter to ensure it does not contain any malicious characters.

1. Create an allow-list of acceptable domains.
2. Validate the `api_domain` against this allow-list.
3. Ensure the `username` parameter is sanitized to prevent any potential injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
