### PR TITLE
Fix code scanning alert no. 11: Overly permissive regular expression range

### DIFF
--- a/scripts/preview-theme.js
+++ b/scripts/preview-theme.js
@@ -336,7 +336,7 @@ const parseJSON = (json) => {
     let parsedJson = json.replace(/(,\s*})/g, "}");
 
     // Remove JS comments (if any).
-    parsedJson = parsedJson.replace(/\/\/[A-z\s]*\s/g, "");
+    parsedJson = parsedJson.replace(/\/\/[A-Za-z\s]*\s/g, "");
 
     // Fix incorrect open bracket (if any).
     const splitJson = parsedJson


### PR DESCRIPTION
Fixes [https://github.com/Necas209/github-readme-stats/security/code-scanning/11](https://github.com/Necas209/github-readme-stats/security/code-scanning/11)

To fix the problem, we need to update the regular expression on line 339 to match only the intended characters. Specifically, we should replace the range `A-z` with `A-Za-z` to ensure that only uppercase and lowercase letters are matched. This change will prevent the regular expression from matching unintended characters and ensure that only valid JavaScript comments are removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
