### PR TITLE
Fix code scanning alert no. 12: Unsafe HTML constructed from library input

### DIFF
--- a/src/common/Card.js
+++ b/src/common/Card.js
@@ -28,7 +28,7 @@ class Card {
     defaultTitle = "",
     titlePrefixIcon,
   }) {
-    this.width = width;
+    this.width = isNaN(width) || width <= 0 ? 100 : width;
     this.height = height;
 
     this.hideBorder = false;


### PR DESCRIPTION
Fixes [https://github.com/Necas209/github-readme-stats/security/code-scanning/12](https://github.com/Necas209/github-readme-stats/security/code-scanning/12)

To fix the problem, we need to ensure that the `width` property is sanitized before being used in constructing the SVG element. This can be done by validating that the `width` is a number and falls within an acceptable range. If the `width` is not valid, we can default to a safe value.

1. **General Fix Approach:**
   - Validate the `width` property to ensure it is a number and within a reasonable range.
   - If the `width` is invalid, default to a safe value.

2. **Detailed Fix:**
   - In the `Card` class constructor, validate the `width` property.
   - If the `width` is not a valid number, set it to a default safe value.

3. **Specific Changes:**
   - Modify the `Card` class constructor in `src/common/Card.js` to include validation for the `width` property.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
